### PR TITLE
Euicc: Add support for OnePlus ACE3 OP5CF9L1

### DIFF
--- a/Euicc/res/values/strings.xml
+++ b/Euicc/res/values/strings.xml
@@ -4,6 +4,6 @@
     SPDX-License-Identifier: Apache-2.0
 -->
 <resources>
-    <string name="sim_illustration_lottie_mappings_json">{\"sim_illustration_lottie_mappings\":[{\"devices\":[\"OP594DL1\",\"OP5D35L1\"],\"illustration_lottie\":\"sim_illustration_lottie_bottom\"}]}</string>
-    <string name="sim_slot_mappings_json">{\"sim-slot-mappings\":[{\"devices\":[\"OP594DL1\",\"OP5D35L1\"],\"esim-slot-ids\":[1],\"psim-slot-ids\":[0]}]}</string>
+    <string name="sim_illustration_lottie_mappings_json">{\"sim_illustration_lottie_mappings\":[{\"devices\":[\"OP594DL1\",\"OP5D35L1\",\"OP5CF9L1\"],\"illustration_lottie\":\"sim_illustration_lottie_bottom\"}]}</string>
+    <string name="sim_slot_mappings_json">{\"sim-slot-mappings\":[{\"devices\":[\"OP594DL1\",\"OP5D35L1\",\"OP5CF9L1\"],\"esim-slot-ids\":[1],\"psim-slot-ids\":[0]}]}</string>
 </resources>


### PR DESCRIPTION
* Fix following errors

E AndroidRuntime: java.lang.RuntimeException: Cannot find SIM slot mapping for device: OP5CF9L1
E AndroidRuntime: Caused by: java.lang.RuntimeException: Cannot find SIM slot mapping for device: OP5CF9L1